### PR TITLE
Added type hints

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -101,7 +101,7 @@ function build_libavif {
     python -m pip install meson ninja
 
     if [[ "$PLAT" == "x86_64" ]]; then
-        build_simple nasm 2.15.05 https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/
+        build_simple nasm 2.16.03 https://www.nasm.us/pub/nasm/releasebuilds/2.16.03/
     fi
 
     local cmake=$(get_modern_cmake)

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -66,21 +66,25 @@ function build_harfbuzz {
 }
 
 function install_rav1e {
-    if [[ -n "$IS_MACOS" ]] && [[ "$PLAT" == "arm64" ]]; then
-        librav1e_tgz=librav1e-${RAV1E_VERSION}-macos-aarch64.tar.gz
-    elif [ -n "$IS_MACOS" ]; then
-        librav1e_tgz=librav1e-${RAV1E_VERSION}-macos.tar.gz
-    elif [ "$PLAT" == "aarch64" ]; then
-        librav1e_tgz=librav1e-${RAV1E_VERSION}-linux-aarch64.tar.gz
+    if [ -n "$IS_MACOS" ]; then
+        suffix="macos"
+        if [[ "$PLAT" == "arm64" ]]; then
+            suffix+="-aarch64"
+        fi
     else
-        librav1e_tgz=librav1e-${RAV1E_VERSION}-linux-generic.tar.gz
+        suffix="linux"
+        if [[ "$PLAT" == "aarch64" ]]; then
+            suffix+="-aarch64"
+        else
+            suffix+="-generic"
+        fi
     fi
 
     curl -sLo - \
-        https://github.com/xiph/rav1e/releases/download/v$RAV1E_VERSION/$librav1e_tgz \
+        https://github.com/xiph/rav1e/releases/download/v$RAV1E_VERSION/librav1e-$RAV1E_VERSION-$suffix.tar.gz \
         | tar -C $BUILD_PREFIX --exclude LICENSE --exclude LICENSE --exclude '*.so' --exclude '*.dylib' -zxf -
 
-    if [ ! -n "$IS_MACOS" ]; then
+    if [ -z "$IS_MACOS" ]; then
         sed -i 's/-lgcc_s/-lgcc_eh/g' "${BUILD_PREFIX}/lib/pkgconfig/rav1e.pc"
     fi
 

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -210,7 +210,7 @@ if [[ -n "$IS_MACOS" ]]; then
     brew remove --ignore-dependencies webp aom libavif
   fi
 
-  brew install meson pkg-config
+  brew install pkg-config
 
   # clear bash path cache for curl
   hash -d curl

--- a/Tests/check_avif_leaks.py
+++ b/Tests/check_avif_leaks.py
@@ -20,7 +20,7 @@ pytestmark = [
 ]
 
 
-def test_leak_load():
+def test_leak_load() -> None:
     from resource import RLIMIT_AS, RLIMIT_STACK, setrlimit
 
     setrlimit(RLIMIT_STACK, (stack_size, stack_size))
@@ -30,7 +30,7 @@ def test_leak_load():
             im.load()
 
 
-def test_leak_save():
+def test_leak_save() -> None:
     from resource import RLIMIT_AS, RLIMIT_STACK, setrlimit
 
     setrlimit(RLIMIT_STACK, (stack_size, stack_size))

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -235,7 +235,7 @@ following options are available::
 **append_images**
     A list of images to append as additional frames. Each of the
     images in the list can be single or multiframe images.
-    This is currently supported for GIF, PDF, PNG, TIFF, WebP, and AVIF.
+    This is currently supported for AVIF, GIF, PDF, PNG, TIFF and WebP.
 
     It is also supported for ICO and ICNS. If images are passed in of relevant
     sizes, they will be used instead of scaling down the main image.
@@ -1321,7 +1321,7 @@ as 8-bit RGB(A).
 The :py:meth:`~PIL.Image.Image.save` method supports the following options:
 
 **quality**
-    Integer, 1-100, Defaults to 90. 0 gives the smallest size and poorest
+    Integer, 1-100, defaults to 90. 0 gives the smallest size and poorest
     quality, 100 the largest and best quality. The value of this setting
     controls the ``qmin`` and ``qmax`` encoder options.
 
@@ -1331,19 +1331,19 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     values are, the worse the quality.
 
 **subsampling**
-    If present, sets the subsampling for the encoder. Defaults to ``"4:2:0``".
+    If present, sets the subsampling for the encoder. Defaults to ``4:2:0``.
     Options include:
 
-    * ``"4:0:0"``
-    * ``"4:2:0"``
-    * ``"4:2:2"``
-    * ``"4:4:4"``
+    * ``4:0:0``
+    * ``4:2:0``
+    * ``4:2:2``
+    * ``4:4:4``
 
 **speed**
     Quality/speed trade-off (0=slower-better, 10=fastest). Defaults to 8.
 
 **range**
-    YUV range, either "full" or "limited." Defaults to "full"
+    YUV range, either "full" or "limited". Defaults to "full"
 
 **codec**
     AV1 codec to use for encoding. Possible values are "aom", "rav1e", and

--- a/src/PIL/AvifImagePlugin.py
+++ b/src/PIL/AvifImagePlugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from io import BytesIO
+from typing import IO
 
 from . import ExifTags, Image, ImageFile
 
@@ -20,9 +21,9 @@ DEFAULT_MAX_THREADS = 0
 _VALID_AVIF_MODES = {"RGB", "RGBA"}
 
 
-def _accept(prefix):
+def _accept(prefix: bytes) -> bool | str:
     if prefix[4:8] != b"ftyp":
-        return
+        return False
     coding_brands = (b"avif", b"avis")
     container_brands = (b"mif1", b"msf1")
     major_brand = prefix[8:12]
@@ -42,6 +43,7 @@ def _accept(prefix):
         # Also, because this file might not actually be an AVIF file, we
         # don't raise an error if AVIF support isn't properly compiled.
         return True
+    return False
 
 
 class AvifImageFile(ImageFile.ImageFile):
@@ -53,7 +55,7 @@ class AvifImageFile(ImageFile.ImageFile):
     def load_seek(self, pos: int) -> None:
         pass
 
-    def _open(self):
+    def _open(self) -> None:
         if not SUPPORTED:
             msg = (
                 "image file could not be identified because AVIF "
@@ -80,13 +82,13 @@ class AvifImageFile(ImageFile.ImageFile):
         if xmp:
             self.info["xmp"] = xmp
 
-    def seek(self, frame):
+    def seek(self, frame: int) -> None:
         if not self._seek_check(frame):
             return
 
         self.__frame = frame
 
-    def load(self):
+    def load(self) -> Image.core.PixelAccess | None:
         if self.__loaded != self.__frame:
             # We need to load the image data for this frame
             data, timescale, tsp_in_ts, dur_in_ts = self._decoder.get_frame(
@@ -102,19 +104,21 @@ class AvifImageFile(ImageFile.ImageFile):
             if self.fp and self._exclusive_fp:
                 self.fp.close()
             self.fp = BytesIO(data)
-            self.tile = [("raw", (0, 0) + self.size, 0, self.rawmode)]
+            self.tile = [ImageFile._Tile("raw", (0, 0) + self.size, 0, self.rawmode)]
 
         return super().load()
 
-    def tell(self):
+    def tell(self) -> int:
         return self.__frame
 
 
-def _save_all(im, fp, filename):
+def _save_all(im: Image.Image, fp: IO[bytes], filename: str | bytes) -> None:
     _save(im, fp, filename, save_all=True)
 
 
-def _save(im, fp, filename, save_all=False):
+def _save(
+    im: Image.Image, fp: IO[bytes], filename: str | bytes, save_all: bool = False
+) -> None:
     info = im.encoderinfo.copy()
     if save_all:
         append_images = list(info.get("append_images", []))

--- a/src/PIL/AvifImagePlugin.py
+++ b/src/PIL/AvifImagePlugin.py
@@ -73,7 +73,6 @@ class AvifImageFile(ImageFile.ImageFile):
         self.n_frames = n_frames
         self.is_animated = self.n_frames > 1
         self._mode = self.rawmode = mode
-        self.tile = []
 
         if icc:
             self.info["icc_profile"] = icc


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/5201

- Added type hints
- Updated nasm to 2.16.03
- Removed installing meson through brew, since it will just be installed by Python later
- Simplified code
- Sort formats alphabetically, and minor docs cleanup.
- `self.tile` is already an empty list. See https://github.com/python-pillow/Pillow/pull/8465