### PR TITLE
Set default max threads in Python

### DIFF
--- a/src/_avif.c
+++ b/src/_avif.c
@@ -306,23 +306,23 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
     AvifEncoderObject *self = NULL;
     avifEncoder *encoder = NULL;
 
-    char *subsampling = "4:2:0";
-    int qmin = AVIF_QUANTIZER_BEST_QUALITY;  // =0
-    int qmax = 10;                           // "High Quality", but not lossless
-    int quality = 75;
-    int speed = 8;
-    int exif_orientation = 0;
-    int max_threads = default_max_threads;
+    char *subsampling;
+    int qmin;
+    int qmax;
+    int quality;
+    int speed;
+    int exif_orientation;
+    int max_threads;
     PyObject *icc_bytes;
     PyObject *exif_bytes;
     PyObject *xmp_bytes;
-    PyObject *alpha_premultiplied = NULL;
-    PyObject *autotiling = NULL;
-    int tile_rows_log2 = 0;
-    int tile_cols_log2 = 0;
+    PyObject *alpha_premultiplied;
+    PyObject *autotiling;
+    int tile_rows_log2;
+    int tile_cols_log2;
 
-    char *codec = "auto";
-    char *range = "full";
+    char *codec;
+    char *range;
 
     PyObject *advanced;
 
@@ -730,7 +730,7 @@ AvifDecoderNew(PyObject *self_, PyObject *args) {
     char *codec_str;
     avifCodecChoice codec;
     avifChromaUpsampling upsampling;
-    int max_threads = 0;
+    int max_threads;
 
     avifResult result;
 

--- a/src/_avif.c
+++ b/src/_avif.c
@@ -44,54 +44,6 @@ typedef struct {
 
 static PyTypeObject AvifDecoder_Type;
 
-static int default_max_threads = 0;
-
-static void
-init_max_threads(void) {
-    PyObject *os = NULL;
-    PyObject *n = NULL;
-    long num_cpus;
-
-    os = PyImport_ImportModule("os");
-    if (os == NULL) {
-        goto error;
-    }
-
-    if (PyObject_HasAttrString(os, "sched_getaffinity")) {
-        n = PyObject_CallMethod(os, "sched_getaffinity", "i", 0);
-        if (n == NULL) {
-            goto error;
-        }
-        num_cpus = PySet_Size(n);
-    } else {
-        n = PyObject_CallMethod(os, "cpu_count", NULL);
-        if (n == NULL) {
-            goto error;
-        }
-        num_cpus = PyLong_AsLong(n);
-    }
-
-    if (num_cpus < 1) {
-        goto error;
-    }
-
-    default_max_threads = (int)num_cpus;
-
-done:
-    Py_XDECREF(os);
-    Py_XDECREF(n);
-    return;
-
-error:
-    if (PyErr_Occurred()) {
-        PyErr_Clear();
-    }
-    PyErr_WarnEx(
-        PyExc_RuntimeWarning, "could not get cpu count: using max_threads=1", 1
-    );
-    goto done;
-}
-
 static int
 normalize_quantize_value(int qvalue) {
     if (qvalue < AVIF_QUANTIZER_BEST_QUALITY) {
@@ -438,13 +390,6 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
 
         encoder = avifEncoderCreate();
 
-        if (max_threads == 0) {
-            if (default_max_threads == 0) {
-                init_max_threads();
-            }
-            max_threads = default_max_threads;
-        }
-
         int is_aom_encode = strcmp(codec, "aom") == 0 ||
                             (strcmp(codec, "auto") == 0 &&
                              _codec_available("aom", AVIF_CODEC_FLAG_CAN_ENCODE));
@@ -785,12 +730,6 @@ AvifDecoderNew(PyObject *self_, PyObject *args) {
 
     self->decoder = avifDecoderCreate();
 #if AVIF_VERSION >= 80400
-    if (max_threads == 0) {
-        if (default_max_threads == 0) {
-            init_max_threads();
-        }
-        max_threads = default_max_threads;
-    }
     self->decoder->maxThreads = max_threads;
 #endif
 #if AVIF_VERSION >= 90200


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/5201

1. Removed initial values for C variables that are just going to be set by `PyArg_ParseTuple` anyway.
2. Set default max threads in Python. See what you think of this - it seems simpler to me to pass through the value from Python rather than calling Python code from C.