### PR TITLE
Removed ld64 flag

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -168,12 +168,7 @@ function build {
     fi
     build_new_zlib
 
-    ORIGINAL_LDFLAGS=$LDFLAGS
-    if [[ -n "$IS_MACOS" ]] && [[ "$CIBW_ARCHS" == "arm64" ]]; then
-        LDFLAGS="${LDFLAGS} -ld64"
-    fi
     build_libavif
-    LDFLAGS=$ORIGINAL_LDFLAGS
 
     build_simple xcb-proto 1.17.0 https://xorg.freedesktop.org/archive/individual/proto
     if [ -n "$IS_MACOS" ]; then


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/5201

Since you're already adding EXIF data to the saved file with `avifImageSetMetadataExif`, it would seem unnecessary to also use `exif_orientation_to_irot_imir`?

I've removed `get_modern_cmake`, since https://github.com/python-pillow/Pillow/pull/8497 added `python3 -m pip install cmake` instead, and the goal of that PR was to try and avoid using brew, which `get_modern_cmake` [does.](https://github.com/multi-build/multibuild/blob/9a9d1275f025f737cdaa3c451ba07129dd95f361/library_builders.sh#L199-L217)

I saw that `_avif.AvifCodecVersions()` was only ever called from the test suite, so I've removed that.