### PR TITLE
Do not ignore SyntaxError when saving EXIF data

### DIFF
--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -353,7 +353,7 @@ class TestFileAvif:
     def test_exif_invalid(self, tmp_path: Path) -> None:
         with Image.open(TEST_AVIF_FILE) as im:
             test_file = str(tmp_path / "temp.avif")
-            with pytest.raises(ValueError):
+            with pytest.raises(SyntaxError):
                 im.save(test_file, exif=b"invalid")
 
     def test_xmp(self) -> None:

--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -329,17 +329,8 @@ class TestFileAvif:
             exif = im.getexif()
         assert exif[274] == 3
 
-    def test_exif_save_default(self, tmp_path: Path) -> None:
-        with Image.open("Tests/images/avif/exif.avif") as im:
-            test_file = str(tmp_path / "temp.avif")
-            im.save(test_file)
-
-        with Image.open(test_file) as reloaded:
-            exif = reloaded.getexif()
-        assert exif[274] == 1
-
     @pytest.mark.parametrize("bytes", [True, False])
-    def test_exif_save_argument(self, tmp_path: Path, bytes: bool) -> None:
+    def test_exif_save(self, tmp_path: Path, bytes: bool) -> None:
         exif = Image.Exif()
         exif[274] = 1
         exif_data = exif.tobytes()
@@ -362,24 +353,6 @@ class TestFileAvif:
         assert_xmp_orientation(xmp, 3)
 
     def test_xmp_save(self, tmp_path: Path) -> None:
-        with Image.open("Tests/images/avif/xmp_tags_orientation.avif") as im:
-            test_file = str(tmp_path / "temp.avif")
-            im.save(test_file)
-
-        with Image.open(test_file) as reloaded:
-            xmp = reloaded.info["xmp"]
-        assert_xmp_orientation(xmp, 3)
-
-    def test_xmp_save_from_png(self, tmp_path: Path) -> None:
-        with Image.open("Tests/images/xmp_tags_orientation.png") as im:
-            test_file = str(tmp_path / "temp.avif")
-            im.save(test_file)
-
-        with Image.open(test_file) as reloaded:
-            xmp = reloaded.info["xmp"]
-        assert_xmp_orientation(xmp, 3)
-
-    def test_xmp_save_argument(self, tmp_path: Path) -> None:
         xmp_arg = "\n".join(
             [
                 '<?xpacket begin="" id="W5M0MpCehiHzreSzNTczkc9d"?>',

--- a/src/PIL/AvifImagePlugin.py
+++ b/src/PIL/AvifImagePlugin.py
@@ -169,7 +169,6 @@ def _save(
 
     icc_profile = info.get("icc_profile", im.info.get("icc_profile"))
     exif = info.get("exif", im.info.get("exif"))
-    exif_orientation = 0
     if exif:
         if isinstance(exif, Image.Exif):
             exif_data = exif
@@ -177,7 +176,9 @@ def _save(
         else:
             exif_data = Image.Exif()
             exif_data.load(exif)
-        exif_orientation = exif_data.get(ExifTags.Base.Orientation, 0)
+        exif_orientation = exif_data.pop(ExifTags.Base.Orientation, 1)
+    else:
+        exif_orientation = 1
 
     xmp = info.get("xmp", im.info.get("xmp") or im.info.get("XML:com.adobe.xmp"))
 

--- a/src/PIL/AvifImagePlugin.py
+++ b/src/PIL/AvifImagePlugin.py
@@ -169,21 +169,15 @@ def _save(
 
     icc_profile = info.get("icc_profile", im.info.get("icc_profile"))
     exif = info.get("exif", im.info.get("exif"))
-    if isinstance(exif, Image.Exif):
-        exif = exif.tobytes()
-
     exif_orientation = 0
     if exif:
-        exif_data = Image.Exif()
-        try:
-            exif_data.load(exif)
-        except SyntaxError:
-            pass
+        if isinstance(exif, Image.Exif):
+            exif_data = exif
+            exif = exif.tobytes()
         else:
-            orientation_tag = next(
-                k for k, v in ExifTags.TAGS.items() if v == "Orientation"
-            )
-            exif_orientation = exif_data.get(orientation_tag) or 0
+            exif_data = Image.Exif()
+            exif_data.load(exif)
+        exif_orientation = exif_data.get(ExifTags.Base.Orientation, 0)
 
     xmp = info.get("xmp", im.info.get("xmp") or im.info.get("XML:com.adobe.xmp"))
 

--- a/src/PIL/AvifImagePlugin.py
+++ b/src/PIL/AvifImagePlugin.py
@@ -168,7 +168,7 @@ def _save(
     autotiling = bool(info.get("autotiling", tile_rows_log2 == tile_cols_log2 == 0))
 
     icc_profile = info.get("icc_profile", im.info.get("icc_profile"))
-    exif = info.get("exif", im.info.get("exif"))
+    exif = info.get("exif")
     if exif:
         if isinstance(exif, Image.Exif):
             exif_data = exif
@@ -180,7 +180,7 @@ def _save(
     else:
         exif_orientation = 1
 
-    xmp = info.get("xmp", im.info.get("xmp") or im.info.get("XML:com.adobe.xmp"))
+    xmp = info.get("xmp")
 
     if isinstance(xmp, str):
         xmp = xmp.encode("utf-8")

--- a/src/_avif.c
+++ b/src/_avif.c
@@ -170,22 +170,7 @@ exif_orientation_to_irot_imir(avifImage *image, int orientation) {
             image->imir.mode = 0;  // ignored
 #endif
             return;
-        default:  // reserved
-            break;
     }
-
-    // The orientation tag is not mandatory (only recommended) according to JEITA
-    // CP-3451C section 4.6.8.A. The default value is 1 if the orientation tag is
-    // missing, meaning:
-    //   The 0th row is at the visual top of the image, and the 0th column is the visual
-    //   left-hand side.
-    image->transformFlags = otherFlags;
-    image->irot.angle = 0;  // ignored
-#if AVIF_VERSION_MAJOR >= 1
-    image->imir.axis = 0;  // ignored
-#else
-    image->imir.mode = 0;  // ignored
-#endif
 }
 
 static int


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/5201

- Do not ignore SyntaxError when saving EXIF data - see https://github.com/python-pillow/Pillow/pull/5201#discussion_r1867201565
- Do not save orientation in EXIF data, so that only imir/irot is used
- Do not save XMP and EXIF data from info dictionary - see https://github.com/python-pillow/Pillow/pull/5201#discussion_r1807180694