### PR TITLE
Use cmds_cmake

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -139,10 +139,6 @@ jobs:
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_libpng.cmd"
 
-    - name: Build dependencies / meson
-      if: steps.build-cache.outputs.cache-hit != 'true'
-      run: "& winbuild\\build\\install_meson.cmd"
-
     - name: Build dependencies / libavif
       if: steps.build-cache.outputs.cache-hit != 'true'
       run: "& winbuild\\build\\build_dep_libavif.cmd"

--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -100,7 +100,7 @@ function build_harfbuzz {
 function build_libavif {
     if [ -e libavif-stamp ]; then return; fi
 
-    if [[ -z "$IS_MACOS" ]] && ([[ "$MB_ML_VER" == 2014 ]] || [[ "$PLAT" == "aarch64" ]]); then
+    if [[ "$MB_ML_VER" == 2014 ]] || [[ "$PLAT" == "aarch64" ]]; then
         # Once Amazon 2 is EOL on 30 June 2025, manylinux2014 will no longer be needed
         # Once GitHub Actions supports aarch64 without emulation, this will no longer needed as building will be faster
         if [[ "$PLAT" == "aarch64" ]]; then

--- a/depends/install_libavif.sh
+++ b/depends/install_libavif.sh
@@ -51,6 +51,7 @@ fi
 
 cmake -G Ninja -S . -B build \
     -DCMAKE_INSTALL_PREFIX=$PREFIX \
+    -DAVIF_LIBSHARPYUV=LOCAL \
     -DAVIF_LIBYUV=LOCAL \
     -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_INSTALL_NAME_DIR=$PREFIX/lib \

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -405,35 +405,19 @@ DEPS: dict[str, dict[str, Any]] = {
         "dir": f"libavif-{V['LIBAVIF']}",
         "license": "LICENSE",
         "build": [
-            cmd_mkdir("build.pillow"),
-            cmd_cd("build.pillow"),
-            " ".join(
-                [
-                    "{cmake}",
-                    "-DCMAKE_BUILD_TYPE=Release",
-                    "-DCMAKE_VERBOSE_MAKEFILE=ON",
-                    "-DCMAKE_RULE_MESSAGES:BOOL=OFF",
-                    "-DCMAKE_C_COMPILER=cl.exe",
-                    "-DCMAKE_CXX_COMPILER=cl.exe",
-                    "-DCMAKE_C_FLAGS=-nologo",
-                    "-DCMAKE_CXX_FLAGS=-nologo",
-                    "-DBUILD_SHARED_LIBS=OFF",
-                    "-DAVIF_CODEC_AOM=LOCAL",
-                    "-DAVIF_LIBYUV=LOCAL",
-                    "-DAVIF_LIBSHARPYUV=LOCAL",
-                    "-DAVIF_CODEC_RAV1E=LOCAL",
-                    "-DCMAKE_MODULE_PATH={winbuild_dir_cmake}",
-                    "-DAVIF_CODEC_DAV1D=LOCAL",
-                    "-DAVIF_CODEC_SVT=LOCAL",
-                    '-G "Ninja"',
-                    "..",
-                ]
+            *cmds_cmake(
+                "avif_static",
+                "-DBUILD_SHARED_LIBS=OFF",
+                "-DAVIF_CODEC_AOM=LOCAL",
+                "-DAVIF_LIBYUV=LOCAL",
+                "-DAVIF_LIBSHARPYUV=LOCAL",
+                "-DAVIF_CODEC_RAV1E=LOCAL",
+                "-DAVIF_CODEC_DAV1D=LOCAL",
+                "-DAVIF_CODEC_SVT=LOCAL",
             ),
-            "ninja -v",
-            cmd_cd(".."),
             cmd_xcopy("include", "{inc_dir}"),
         ],
-        "libs": [r"build.pillow\avif.lib"],
+        "libs": ["avif.lib"],
     },
 }
 
@@ -796,7 +780,6 @@ def main() -> None:
         **arch_prefs,
         # Pillow paths
         "winbuild_dir": winbuild_dir,
-        "winbuild_dir_cmake": winbuild_dir.replace("\\", "/"),
         # Build paths
         "bin_dir": bin_dir,
         "build_dir": args.build_dir,

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -122,7 +122,6 @@ V = {
     "TIFF": "4.6.0",
     "XZ": "5.6.3",
     "ZLIB": "1.3.1",
-    "MESON": "1.6.0",
     "LIBAVIF": "1.1.1",
 }
 V["LIBPNG_DOTLESS"] = V["LIBPNG"].replace(".", "")
@@ -405,6 +404,7 @@ DEPS: dict[str, dict[str, Any]] = {
         "dir": f"libavif-{V['LIBAVIF']}",
         "license": "LICENSE",
         "build": [
+            f"{sys.executable} -m pip install meson",
             *cmds_cmake(
                 "avif_static",
                 "-DBUILD_SHARED_LIBS=OFF",
@@ -647,19 +647,13 @@ def build_dep_all(disabled: list[str], prefs: dict[str, str], verbose: bool) -> 
         if dep_name in disabled:
             print(f"Skipping disabled dependency {dep_name}")
             continue
-
-        scripts = []
-        if dep_name == "libavif":
-            scripts.append("install_meson.cmd")
-        scripts.append(build_dep(dep_name, prefs, verbose))
-
-        for script in scripts:
-            if gha_groups:
-                lines.append(f"@echo ::group::Running {script}")
-            lines.append(rf'cmd.exe /c "{{build_dir}}\{script}"')
-            lines.append("if errorlevel 1 echo Build failed! && exit /B 1")
-            if gha_groups:
-                lines.append("@echo ::endgroup::")
+        script = build_dep(dep_name, prefs, verbose)
+        if gha_groups:
+            lines.append(f"@echo ::group::Running {script}")
+        lines.append(rf'cmd.exe /c "{{build_dir}}\{script}"')
+        lines.append("if errorlevel 1 echo Build failed! && exit /B 1")
+        if gha_groups:
+            lines.append("@echo ::endgroup::")
     print()
     lines.append("@echo All Pillow dependencies built successfully!")
     write_script("build_dep_all.cmd", lines, prefs, verbose)
@@ -801,19 +795,6 @@ def main() -> None:
     print()
 
     write_script(".gitignore", ["*"], prefs, args.verbose)
-    if "libavif" not in disabled:
-        write_script(
-            "install_meson.cmd",
-            [
-                r'call "{build_dir}\build_env.cmd"',
-                "@echo " + ("=" * 70),
-                f"@echo ==== {'Building meson':<60} ====",
-                "@echo " + ("=" * 70),
-                f"{sys.executable} -m pip install meson=={V['MESON']}",
-            ],
-            prefs,
-            args.verbose,
-        )
     build_env(prefs, args.verbose)
     build_dep_all(disabled, prefs, args.verbose)
 


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/5201

- meson isn't a direct dependency, so I don't think it needs a dedicated build script. I don't expect the meson version to make a different to the final functionality of Pillow.

- https://github.com/multi-build/multibuild/pull/541 has been included in Pillow with https://github.com/python-pillow/Pillow/pull/8593, so `MB_ML_VER` will no longer be 2014 on macOS