### PR TITLE
Removed unittest mock

### DIFF
--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         python-version: ["pypy3.10", "3.9", "3.10", "3.11", "3.12", "3.13"]
 
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     name: Python ${{ matrix.python-version }}
 

--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -10,7 +10,6 @@ from io import BytesIO
 from pathlib import Path
 from struct import unpack
 from typing import Any
-from unittest import mock
 
 import pytest
 
@@ -334,12 +333,9 @@ class TestFileAvif:
     def test_exif_save(
         self,
         tmp_path: Path,
-        monkeypatch: pytest.MonkeyPatch,
         bytes: bool,
         orientation: int,
     ) -> None:
-        mock_avif_encoder = mock.Mock(wraps=_avif.AvifEncoder)
-        monkeypatch.setattr(_avif, "AvifEncoder", mock_avif_encoder)
         exif = Image.Exif()
         exif[274] = orientation
         exif_data = exif.tobytes()
@@ -352,7 +348,6 @@ class TestFileAvif:
                 assert "exif" not in reloaded.info
             else:
                 assert reloaded.info["exif"] == exif_data
-        mock_avif_encoder.mock_calls[0].args[16:17] == (b"", orientation)
 
     def test_exif_invalid(self, tmp_path: Path) -> None:
         with Image.open(TEST_AVIF_FILE) as im:

--- a/wheels/dependency_licenses/LIBAVIF.txt
+++ b/wheels/dependency_licenses/LIBAVIF.txt
@@ -51,7 +51,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ------------------------------------------------------------------------------
 
-Files: apps/shared/iccjpeg.*
+Files: third_party/iccjpeg/*
 
 In plain English:
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/5201

Pillow moved away from unittest in https://github.com/python-pillow/Pillow/issues/4193, but I also don't think we need to test the interface between Python and C - asserting that the orientation is in the opened image should be enough.

https://github.com/python-pillow/Pillow/actions/runs/12314975919/job/34372579893 failed because the 30 minute timeout was reached. So I suggest increasing the timeout by 15 minutes to account for the libavif build script.