### PR TITLE
Removed alpha_premultiplied

### DIFF
--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -662,18 +662,14 @@ class TestAvifAnimation:
             with Image.open("Tests/images/avif/rgba10.heif"):
                 pass
 
-    @pytest.mark.parametrize("alpha_premultiplied", [False, True])
-    def test_alpha_premultiplied(
-        self, tmp_path: Path, alpha_premultiplied: bool
-    ) -> None:
+    def test_alpha_premultiplied(self, tmp_path: Path) -> None:
         temp_file = str(tmp_path / "temp.avif")
-        color = (200, 200, 200, 1)
-        im = Image.new("RGBA", (1, 1), color)
-        im.save(temp_file, alpha_premultiplied=alpha_premultiplied)
+        im = Image.new("RGBa", (1, 1), (200, 200, 200, 1))
+        im.save(temp_file)
 
-        expected = (255, 255, 255, 1) if alpha_premultiplied else color
         with Image.open(temp_file) as reloaded:
-            assert reloaded.getpixel((0, 0)) == expected
+            assert reloaded.mode == "RGBA"
+            assert reloaded.getpixel((0, 0)) == (255, 255, 255, 1)
 
     def test_timestamp_and_duration(self, tmp_path: Path) -> None:
         """

--- a/docs/handbook/image-file-formats.rst
+++ b/docs/handbook/image-file-formats.rst
@@ -71,10 +71,6 @@ The :py:meth:`~PIL.Image.Image.save` method supports the following options:
     and "tile_cols" both have their default values of zero. Requires libavif version
     **0.11.0** or greater.
 
-**alpha_premultiplied**
-    Encode the image with premultiplied alpha. Defaults to ``False``. Requires libavif
-    version **0.9.0** or greater.
-
 **advanced**
     Codec specific options. Requires libavif version **0.8.2** or greater.
 

--- a/src/PIL/AvifImagePlugin.py
+++ b/src/PIL/AvifImagePlugin.py
@@ -4,7 +4,7 @@ import os
 from io import BytesIO
 from typing import IO
 
-from . import ExifTags, Image, ImageFile
+from . import ExifTags, Image, ImageFile, features
 
 try:
     from . import _avif
@@ -164,7 +164,6 @@ def _save(
     range_ = info.get("range", "full")
     tile_rows_log2 = info.get("tile_rows", 0)
     tile_cols_log2 = info.get("tile_cols", 0)
-    alpha_premultiplied = bool(info.get("alpha_premultiplied", False))
     autotiling = bool(info.get("autotiling", tile_rows_log2 == tile_cols_log2 == 0))
 
     icc_profile = info.get("icc_profile", im.info.get("icc_profile"))
@@ -214,7 +213,6 @@ def _save(
         range_,
         tile_rows_log2,
         tile_cols_log2,
-        alpha_premultiplied,
         autotiling,
         icc_profile or b"",
         exif or b"",
@@ -228,6 +226,17 @@ def _save(
     frame_duration = 0
     cur_idx = im.tell()
     is_single_frame = total == 1
+    supported_modes = {"RGB", "RGBA"}
+
+    try:
+        from packaging.version import parse as parse_version
+    except ImportError:
+        pass
+    else:
+        version = features.version_module("avif")
+        assert version is not None
+        if parse_version(version) > parse_version("0.9.0"):
+            supported_modes.add("RGBa")
     try:
         for ims in [im] + append_images:
             # Get # of frames in this image
@@ -239,7 +248,7 @@ def _save(
                 # Make sure image mode is supported
                 frame = ims
                 rawmode = ims.mode
-                if ims.mode not in {"RGB", "RGBA"}:
+                if ims.mode not in supported_modes:
                     rawmode = "RGBA" if ims.has_transparency_data else "RGB"
                     frame = ims.convert(rawmode)
 

--- a/src/_avif.c
+++ b/src/_avif.c
@@ -241,7 +241,6 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
     Py_buffer icc_buffer;
     Py_buffer exif_buffer;
     Py_buffer xmp_buffer;
-    int alpha_premultiplied;
     int autotiling;
     int tile_rows_log2;
     int tile_cols_log2;
@@ -254,7 +253,7 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
 
     if (!PyArg_ParseTuple(
             args,
-            "(II)siiissiippy*y*iy*O",
+            "(II)siiissiipy*y*iy*O",
             &width,
             &height,
             &subsampling,
@@ -265,7 +264,6 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
             &range,
             &tile_rows_log2,
             &tile_cols_log2,
-            &alpha_premultiplied,
             &autotiling,
             &icc_buffer,
             &exif_buffer,
@@ -318,9 +316,6 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
     image->height = height;
 
     image->depth = 8;
-#if AVIF_VERSION >= 90000
-    image->alphaPremultiplied = alpha_premultiplied ? AVIF_TRUE : AVIF_FALSE;
-#endif
 
     encoder = avifEncoderCreate();
     if (!encoder) {
@@ -537,17 +532,19 @@ _encoder_add(AvifEncoderObject *self, PyObject *args) {
         frame->yuvRange = image->yuvRange;
         frame->yuvFormat = image->yuvFormat;
         frame->depth = image->depth;
-#if AVIF_VERSION >= 90000
-        frame->alphaPremultiplied = image->alphaPremultiplied;
-#endif
     }
 
     avifRGBImageSetDefaults(&rgb, frame);
 
-    if (strcmp(mode, "RGBA") == 0) {
-        rgb.format = AVIF_RGB_FORMAT_RGBA;
-    } else {
+    if (strcmp(mode, "RGB") == 0) {
         rgb.format = AVIF_RGB_FORMAT_RGB;
+    } else {
+        rgb.format = AVIF_RGB_FORMAT_RGBA;
+#if AVIF_VERSION >= 90000
+        if (strcmp(mode, "RGBa") == 0) {
+            frame->alphaPremultiplied = AVIF_TRUE;
+        }
+#endif
     }
 
     result = avifRGBImageAllocatePixels(&rgb);


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/5201

To my simple way of thinking, `alpha_premultiplied` would cause the saved image to no longer be accurate to the Pillow image being saved. So I suggest removing it.