### PR TITLE
Use default PyTypeObject values

### DIFF
--- a/src/_avif.c
+++ b/src/_avif.c
@@ -883,7 +883,6 @@ static PyTypeObject AvifEncoder_Type = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "AvifEncoder",
     .tp_basicsize = sizeof(AvifEncoderObject),
     .tp_dealloc = (destructor)_encoder_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = _encoder_methods,
 };
 
@@ -899,7 +898,6 @@ static PyTypeObject AvifDecoder_Type = {
     PyVarObject_HEAD_INIT(NULL, 0).tp_name = "AvifDecoder",
     .tp_basicsize = sizeof(AvifDecoderObject),
     .tp_dealloc = (destructor)_decoder_dealloc,
-    .tp_flags = Py_TPFLAGS_DEFAULT,
     .tp_methods = _decoder_methods,
 };
 


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/5201

As per https://github.com/python-pillow/Pillow/pull/8741/commits/422c0f607d04470729768c3204273894c9be9e46 from #8741