### PR TITLE
Updated libavif to 1.2.1

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -50,7 +50,7 @@ LIBWEBP_VERSION=1.5.0
 BZIP2_VERSION=1.0.8
 LIBXCB_VERSION=1.17.0
 BROTLI_VERSION=1.1.0
-LIBAVIF_VERSION=1.1.1
+LIBAVIF_VERSION=1.2.1
 
 function build_pkg_config {
     if [ -e pkg-config-stamp ]; then return; fi

--- a/depends/install_libavif.sh
+++ b/depends/install_libavif.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-version=1.1.1
+version=1.2.1
 
 ./download-and-extract.sh libavif-$version https://github.com/AOMediaCodec/libavif/archive/refs/tags/v$version.tar.gz
 

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -116,7 +116,7 @@ V = {
     "HARFBUZZ": "10.4.0",
     "JPEGTURBO": "3.1.0",
     "LCMS2": "2.17",
-    "LIBAVIF": "1.1.1",
+    "LIBAVIF": "1.2.1",
     "LIBIMAGEQUANT": "4.3.4",
     "LIBPNG": "1.6.47",
     "LIBWEBP": "1.5.0",


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/5201

libavif 1.2.1 has been released - https://github.com/AOMediaCodec/libavif/releases/tag/v1.2.1