### PR TITLE
fix: compiler errors in libavif < 1.0.0

### DIFF
--- a/src/_avif.c
+++ b/src/_avif.c
@@ -212,6 +212,9 @@ _add_codec_specific_options(avifEncoder *encoder, PyObject *opts) {
             return 1;
         }
 
+#if AVIF_VERSION < 1000000
+        avifEncoderSetCodecSpecificOption(encoder, key, val);
+#else
         avifResult result = avifEncoderSetCodecSpecificOption(encoder, key, val);
         if (result != AVIF_RESULT_OK) {
             PyErr_Format(
@@ -221,6 +224,7 @@ _add_codec_specific_options(avifEncoder *encoder, PyObject *opts) {
             );
             return 1;
         }
+#endif
     }
     return 0;
 }
@@ -388,9 +392,14 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
     }
     self->first_frame = 1;
 
-    avifResult result;
     if (icc_buffer.len) {
-        result = avifImageSetProfileICC(image, icc_buffer.buf, icc_buffer.len);
+#if AVIF_VERSION < 1000000
+        avifImageSetProfileICC(
+            image, (uint8_t *)PyBytes_AS_STRING(icc_bytes), PyBytes_GET_SIZE(icc_bytes)
+        );
+#else
+        avifResult result =
+            avifImageSetProfileICC(image, icc_buffer.buf, icc_buffer.len);
         if (result != AVIF_RESULT_OK) {
             PyErr_Format(
                 exc_type_for_avif_result(result),
@@ -400,6 +409,7 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
             error = 1;
             goto end;
         }
+#endif
         // colorPrimaries and transferCharacteristics are ignored when an ICC
         // profile is present, so set them to UNSPECIFIED.
         image->colorPrimaries = AVIF_COLOR_PRIMARIES_UNSPECIFIED;
@@ -411,7 +421,15 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
     image->matrixCoefficients = AVIF_MATRIX_COEFFICIENTS_BT601;
 
     if (exif_buffer.len) {
-        result = avifImageSetMetadataExif(image, exif_buffer.buf, exif_buffer.len);
+#if AVIF_VERSION < 1000000
+        avifImageSetMetadataExif(
+            image,
+            (uint8_t *)PyBytes_AS_STRING(exif_bytes),
+            PyBytes_GET_SIZE(exif_bytes)
+        );
+#else
+        avifResult result =
+            avifImageSetMetadataExif(image, exif_buffer.buf, exif_buffer.len);
         if (result != AVIF_RESULT_OK) {
             PyErr_Format(
                 exc_type_for_avif_result(result),
@@ -421,10 +439,17 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
             error = 1;
             goto end;
         }
+#endif
     }
 
     if (xmp_buffer.len) {
-        result = avifImageSetMetadataXMP(image, xmp_buffer.buf, xmp_buffer.len);
+#if AVIF_VERSION < 1000000
+        avifImageSetMetadataXMP(
+            image, (uint8_t *)PyBytes_AS_STRING(xmp_bytes), PyBytes_GET_SIZE(xmp_bytes)
+        );
+#else
+        avifResult result =
+            avifImageSetMetadataXMP(image, xmp_buffer.buf, xmp_buffer.len);
         if (result != AVIF_RESULT_OK) {
             PyErr_Format(
                 exc_type_for_avif_result(result),
@@ -434,6 +459,7 @@ AvifEncoderNew(PyObject *self_, PyObject *args) {
             error = 1;
             goto end;
         }
+#endif
     }
 
     if (exif_orientation > 1) {
@@ -550,6 +576,9 @@ _encoder_add(AvifEncoderObject *self, PyObject *args) {
         rgb.format = AVIF_RGB_FORMAT_RGB;
     }
 
+#if AVIF_VERSION < 1000000
+    avifRGBImageAllocatePixels(&rgb);
+#else
     result = avifRGBImageAllocatePixels(&rgb);
     if (result != AVIF_RESULT_OK) {
         PyErr_Format(
@@ -560,6 +589,7 @@ _encoder_add(AvifEncoderObject *self, PyObject *args) {
         error = 1;
         goto end;
     }
+#endif
 
     if (rgb.rowBytes * rgb.height != size) {
         PyErr_Format(
@@ -820,6 +850,9 @@ _decoder_get_frame(AvifDecoderObject *self, PyObject *args) {
     rgb.depth = 8;
     rgb.format = decoder->alphaPresent ? AVIF_RGB_FORMAT_RGBA : AVIF_RGB_FORMAT_RGB;
 
+#if AVIF_VERSION < 1000000
+    avifRGBImageAllocatePixels(&rgb);
+#else
     result = avifRGBImageAllocatePixels(&rgb);
     if (result != AVIF_RESULT_OK) {
         PyErr_Format(
@@ -829,6 +862,7 @@ _decoder_get_frame(AvifDecoderObject *self, PyObject *args) {
         );
         return NULL;
     }
+#endif
 
     Py_BEGIN_ALLOW_THREADS;
     result = avifImageYUVToRGB(image, &rgb);


### PR DESCRIPTION
As noted in a changelog entry for libavif 1.0.0:

> `avifRGBImageAllocatePixels()`, `avifRWDataRealloc()`, `avifRWDataSet()`, `avifImageSetProfileICC()`, `avifImageSetMetadataExif()`, and `avifImageSetMetadataXMP()` now return `avifResult` instead of `void` to report memory allocation failures

We can only look at and raise exceptions on the return value for libavif versions >= 1.0.0. Earlier versions of libavif fail with compilation errors.

I noticed this when I went to include the changes from my pillow branch, including the PRs that have been merged in, in pillow-avif-plugin. Some of my CI jobs build against earlier versions of libavif, which is how I caught the regression.

cc @radarhere @hugovk