### PR TITLE
feat: Add feature version for avif_codecs

### DIFF
--- a/Tests/test_file_avif.py
+++ b/Tests/test_file_avif.py
@@ -96,6 +96,11 @@ class TestFileAvif:
         assert version is not None
         assert re.search(r"\d+\.\d+\.\d+$", version)
 
+    def test_codec_versions(self) -> None:
+        codec_versions = features.version_module("avif_codecs")
+        assert codec_versions is not None
+        assert re.search(r"\w+ \[(enc|dec|enc/dec)\]:v?\d+\.\d+\.\d+", codec_versions)
+
     def test_read(self) -> None:
         """
         Can we read an AVIF file without error?

--- a/src/PIL/features.py
+++ b/src/PIL/features.py
@@ -18,6 +18,7 @@ modules = {
     "littlecms2": ("PIL._imagingcms", "littlecms_version"),
     "webp": ("PIL._webp", "webpdecoder_version"),
     "avif": ("PIL._avif", "libavif_version"),
+    "avif_codecs": ("PIL._avif", "libavif_codec_versions"),
 }
 
 

--- a/src/_avif.c
+++ b/src/_avif.c
@@ -924,6 +924,12 @@ setup_module(PyObject *m) {
     PyDict_SetItemString(d, "libavif_version", v ? v : Py_None);
     Py_XDECREF(v);
 
+    char codecVersions[256];
+    avifCodecVersions(codecVersions);
+    v = PyUnicode_FromString(codecVersions);
+    PyDict_SetItemString(d, "libavif_codec_versions", v ? v : Py_None);
+    Py_XDECREF(v);
+
     return 0;
 }
 


### PR DESCRIPTION
This exposes the value from `avifCodecVersions()`, which would allow users of the library to confirm the versions of codecs before trying to use codec-specific options (such as tune=iq or avif=1 in aom and SVT-AV1, respectively).

cc: @radarhere