### PR TITLE
Temporarily disable rav1e in WIndows build

### DIFF
--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -392,7 +392,7 @@ DEPS: dict[str, dict[str, Any]] = {
                 "-DAVIF_LIBYUV=LOCAL",
                 "-DAVIF_CODEC_AOM=LOCAL",
                 "-DAVIF_CODEC_DAV1D=LOCAL",
-                "-DAVIF_CODEC_RAV1E=LOCAL",
+                # "-DAVIF_CODEC_RAV1E=LOCAL",
                 "-DAVIF_CODEC_SVT=LOCAL",
             ),
             cmd_xcopy("include", "{inc_dir}"),


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/5201

The Windows wheel job is failing at the moment - https://github.com/python-pillow/Pillow/actions/runs/13997677419/job/39210337036?pr=5201

I'm guessing it's some sort of rust problem. If it isn't fixed in the next week, then we might need to exclude rav1e from the Windows wheels in this Pillow release.