### PR TITLE
Removed CMAKE_INTERPROCEDURAL_OPTIMIZATION

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -143,7 +143,6 @@ function build_libavif {
             -DCONFIG_AV1_DECODER=0 \
             -DAVIF_CODEC_AOM_DECODE=OFF \
             -DAVIF_CODEC_DAV1D=LOCAL \
-            -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON \
             -DCMAKE_BUILD_TYPE=$build_type \
             . \
         && make install)

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -399,7 +399,6 @@ DEPS: dict[str, dict[str, Any]] = {
                 "-DAVIF_CODEC_AOM_DECODE=OFF",
                 "-DAVIF_CODEC_DAV1D=LOCAL",
                 "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
-                "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON",
                 build_type="MinSizeRel",
             ),
             cmd_xcopy("include", "{inc_dir}"),


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/8858

As I think you'll see when this PR is finished building, removing `-DCMAKE_INTERPROCEDURAL_OPTIMIZATION=ON` actually makes the wheel sizes smaller.