### PR TITLE
Include in Windows x86 wheels

### DIFF
--- a/.github/workflows/wheels-dependencies.sh
+++ b/.github/workflows/wheels-dependencies.sh
@@ -111,11 +111,11 @@ function build_libavif {
     local build_type=MinSizeRel
     local lto=ON
 
-    local libavif_cmake_flags=()
+    local libavif_cmake_flags
 
     if [ -n "$IS_MACOS" ]; then
         lto=OFF
-        libavif_cmake_flags+=(
+        libavif_cmake_flags=(
             -DCMAKE_C_FLAGS_MINSIZEREL="-Oz -DNDEBUG -flto " \
             -DCMAKE_CXX_FLAGS_MINSIZEREL="-Oz -DNDEBUG -flto" \
             -DCMAKE_SHARED_LINKER_FLAGS_INIT="-Wl,-S,-x,-dead_strip_dylibs" \
@@ -124,7 +124,7 @@ function build_libavif {
         if [[ "$MB_ML_VER" == 2014 ]] && [[ "$PLAT" == "x86_64" ]]; then
             build_type=Release
         fi
-        libavif_cmake_flags+=(-DCMAKE_SHARED_LINKER_FLAGS_INIT="-Wl,--strip-all,-z,relro,-z,now")
+        libavif_cmake_flags=(-DCMAKE_SHARED_LINKER_FLAGS_INIT="-Wl,--strip-all,-z,relro,-z,now")
     fi
 
     local out_dir=$(fetch_unpack https://github.com/AOMediaCodec/libavif/archive/refs/tags/v$LIBAVIF_VERSION.tar.gz libavif-$LIBAVIF_VERSION.tar.gz)

--- a/Tests/check_wheel.py
+++ b/Tests/check_wheel.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import platform
-import struct
 import sys
 
 from PIL import features
@@ -21,8 +20,8 @@ def test_wheel_modules() -> None:
         except ImportError:
             expected_modules.remove("tkinter")
 
-        # libavif is not available on Windows for x86 and ARM64 architectures
-        if platform.machine() == "ARM64" or struct.calcsize("P") == 4:
+        # libavif is not available on Windows for ARM64 architectures
+        if platform.machine() == "ARM64":
             expected_modules.remove("avif")
 
     assert set(features.get_supported_modules()) == expected_modules

--- a/docs/releasenotes/11.3.0.rst
+++ b/docs/releasenotes/11.3.0.rst
@@ -47,6 +47,12 @@ TODO
 Other changes
 =============
 
+AVIF support in wheels
+^^^^^^^^^^^^^^^^^^^^^^
+
+Support for reading and writing AVIF images is now included in Pillow's wheels, with
+libaom available as an encoder and dav1d as a decoder.
+
 Python 3.14 beta
 ^^^^^^^^^^^^^^^^
 

--- a/winbuild/build_prepare.py
+++ b/winbuild/build_prepare.py
@@ -760,7 +760,7 @@ def main() -> None:
         disabled += ["libimagequant"]
     if args.no_fribidi:
         disabled += ["fribidi"]
-    if args.no_avif or args.architecture != "AMD64":
+    if args.no_avif or args.architecture == "ARM64":
         disabled += ["libavif"]
 
     prefs = {


### PR DESCRIPTION
Suggestion for https://github.com/python-pillow/Pillow/pull/8858

Testing, I found that we can actually use libavif on Windows x86.